### PR TITLE
Add console logger.

### DIFF
--- a/StandAlone.NETCoreApp/Program.cs
+++ b/StandAlone.NETCoreApp/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading;
+using WireMock.Logging;
 using WireMock.Server;
 
 namespace WireMock.Net.StandAlone.NETCoreApp
@@ -12,7 +13,7 @@ namespace WireMock.Net.StandAlone.NETCoreApp
 
         static void Main(string[] args)
         {
-            server = StandAloneApp.Start(args);
+            server = StandAloneApp.Start(args, new WireMockConsoleLogger());
 
             Console.WriteLine($"{DateTime.UtcNow} Press Ctrl+C to shut down");
 


### PR DESCRIPTION
By adding a console logger to the constructor, the stand alone server will log messages to the docker container log, conveniently viewable via `docker logs <mock-server-container-name>`.

An alternate approach might be to allow some sort of environment configuration of logging, such as at least a simple switch to turn on console logging. I will leave this up to others.