### PR TITLE
update Dockerfile with dotnet 5.0

### DIFF
--- a/StandAlone.NETCoreApp/Dockerfile
+++ b/StandAlone.NETCoreApp/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build-env
 
 LABEL maintainer="Stef Heyenrath"
 
@@ -13,7 +13,7 @@ COPY *.cs ./
 RUN dotnet publish -c Release -r linux-x64 -o out
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1-bionic
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-focal
 WORKDIR /app
 COPY --from=build-env /app/out ./
 EXPOSE 80


### PR DESCRIPTION
Hi there, 

I am aware of the change commit 8b6ed9013611a97b2f1844bcf1148155eaa31204, the .net has been upgrade to 5.0 from 3.1. The dockerfile should be updated accordingly. If I still use the dotnet core 3.1 in the dockerfile. The build can be successfully. But the docker run will fail as below error with dotnet compatibility issue.

Commandline arguments are invalid. WireMock.Net cannot start.

Note that the dotnet core runtime only support Ubuntu 20 https://hub.docker.com/_/microsoft-dotnet-aspnet

Happy to discuss. 

Thanks
Yu