### PR TITLE
Update alpine Docker image to fix CVE-2022-48174 and CVE-2023-36799

### DIFF
--- a/StandAlone.NETCoreApp/Dockerfile.alpine
+++ b/StandAlone.NETCoreApp/Dockerfile.alpine
@@ -16,8 +16,6 @@ RUN dotnet publish -c Release -r alpine-x64 -o out \
 
 # build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
-# resolve CVE-2023-2975
-RUN apk upgrade libssl3 libcrypto3 --no-cache
 WORKDIR /app
 COPY --from=build-env /app/out ./
 EXPOSE 80


### PR DESCRIPTION
Currently Trivy reports 2 vulnerabilities (CVE-2022-48174 and CVE-2023-36799) in the latest alpine Docker image. 
To fix them it's enough to build a new image.
In this PR I have removed apk upgrade that is not needed anymore.

[trivy.txt](https://github.com/WireMock-Net/WireMock.Net-docker/files/12915452/trivy.txt)
