### PR TITLE
Add multi-architecture support with Docker Buildx

### DIFF
--- a/StandAlone.NETCoreApp.Local/Dockerfile
+++ b/StandAlone.NETCoreApp.Local/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG TARGETARCH
 
 LABEL maintainer="Stef Heyenrath"
 
@@ -6,11 +7,11 @@ WORKDIR /app
 
 # copy csproj and restore as distinct layers
 COPY StandAlone.NETCoreApp.csproj ./
-RUN dotnet restore
+RUN dotnet restore -a $TARGETARCH
 
 # copy everything else and build
 COPY *.cs ./
-RUN dotnet publish -c Release -r linux-x64 -o out
+RUN dotnet publish -c Release -a $TARGETARCH -o out --no-restore
 
 # build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0

--- a/StandAlone.NETCoreApp/Dockerfile
+++ b/StandAlone.NETCoreApp/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG TARGETARCH
 
 LABEL maintainer="Stef Heyenrath"
 
@@ -6,11 +7,11 @@ WORKDIR /app
 
 # copy csproj and restore as distinct layers
 COPY StandAlone.NETCoreApp.csproj ./
-RUN dotnet restore
+RUN dotnet restore -a $TARGETARCH
 
 # copy everything else and build
 COPY *.cs ./
-RUN dotnet publish -c Release -r linux-x64 -o out
+RUN dotnet publish -c Release -a $TARGETARCH -o out --no-restore
 
 # build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,39 +7,27 @@ variables:
 trigger: none
 
 pool:
-  vmImage: 'Ubuntu-latest'
+  vmImage: 'ubuntu-latest'
 
 steps:
-- task: UseDotNet@2
-  inputs:
-    packageType: 'sdk'
-    version: 8.0.x
-
-- task: DotNetCoreCLI@2
-  displayName: Build StandAlone.NETCoreApp
-  inputs:
-    command: 'build'
-    arguments: /p:Configuration=$(buildConfiguration)
-    projects: $(buildProjects)
-
 - task: Docker@2
-  displayName: 'Build Docker [$(imageName)(latest,$(tag)]'
+  displayName: Login to registry
   inputs:
-    command: 'build'
-    containerRegistry: 'DockerRegistry'
-    repository: '$(DOCKER_ID)/$(imageName)'
-    dockerfile: '$(Build.SourcesDirectory)/StandAlone.NETCoreApp/Dockerfile'
-    tags: |
-      $(tag)
-      latest
+    command: login
+    containerRegistry: DockerRegistry
 
-- task: Docker@2
-  displayName: 'Push Docker [$(imageName)(latest,$(tag)]'
-  inputs:
-    command: 'push'
-    containerRegistry: 'DockerRegistry'
-    repository: '$(DOCKER_ID)/$(imageName)'
-    dockerfile: '$(Build.SourcesDirectory)/StandAlone.NETCoreApp/Dockerfile'
-    tags: |
-      $(tag)
-      latest
+- script: |
+    docker run --privileged --rm tonistiigi/binfmt --install all
+    docker buildx create --use --name builder
+    docker buildx inspect --bootstrap
+  displayName: Set up Docker buildx
+
+- script: |
+    docker buildx build \
+      --platform linux/amd64,linux/arm64,linux/arm/v7 \
+      --tag $(DOCKER_ID)/$(imageName):$(tag) \
+      --tag $(DOCKER_ID)/$(imageName):latest \
+      --file $(Build.SourcesDirectory)/StandAlone.NETCoreApp/Dockerfile \
+      $(Build.SourcesDirectory)/StandAlone.NETCoreApp \
+      --push
+  displayName: 'Build multi-arch Docker image [$(imageName)(latest,$(tag)]'


### PR DESCRIPTION
## Summary

Adds multi-architecture build support for Linux Docker images.

This update modifies the build process so Docker images can be built and published for multiple CPU architectures ( `linux/amd64`, `linux/arm64` and `linux/arm/v7`).

## References

Related Issue: #34 

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
