### PR TITLE
Add multi-architecture (amd64 + arm64) support for the Alpine image

### DIFF
--- a/StandAlone.NETCoreApp/Dockerfile.alpine
+++ b/StandAlone.NETCoreApp/Dockerfile.alpine
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build-env
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build-env
+ARG TARGETARCH
 
 LABEL maintainer="Stef Heyenrath"
 
@@ -6,11 +7,11 @@ WORKDIR /app
 
 # copy csproj and restore as distinct layers
 COPY StandAlone.NETCoreApp.csproj ./
-RUN dotnet restore
+RUN dotnet restore -a $TARGETARCH
 
 # copy everything else and build
 COPY *.cs ./
-RUN dotnet publish -c Release -o out
+RUN dotnet publish -c Release -a $TARGETARCH -o out --no-restore
 
 # build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
@@ -23,5 +24,5 @@ ENTRYPOINT ["./wiremock-net", "--Urls", "http://*:80"]
 CMD ["--WireMockLogger", "WireMockConsoleLogger"]
 
 # Just some info:
-# build with : docker build -t sheyenrath/wiremock.net-alpine -f Dockerfile.alpine .
+# build with : docker buildx build --platform linux/amd64,linux/arm64 -t sheyenrath/wiremock.net-alpine -f Dockerfile.alpine .
 # run with   : docker run --rm -p 9091:80 sheyenrath/wiremock.net-alpine

--- a/azure-pipelines-alpine.yml
+++ b/azure-pipelines-alpine.yml
@@ -7,39 +7,27 @@ variables:
 trigger: none
 
 pool:
-  vmImage: 'Ubuntu-latest'
+  vmImage: 'ubuntu-latest'
 
 steps:
-- task: UseDotNet@2
-  inputs:
-    packageType: 'sdk'
-    version: 8.0.x
-
-- task: DotNetCoreCLI@2
-  displayName: Build StandAlone.NETCoreApp
-  inputs:
-    command: 'build'
-    arguments: /p:Configuration=$(buildConfiguration)
-    projects: $(buildProjects)
-
 - task: Docker@2
-  displayName: 'Build Docker [$(imageName)(latest,$(tag)]'
+  displayName: Login to registry
   inputs:
-    command: 'build'
-    containerRegistry: 'DockerRegistry'
-    repository: '$(DOCKER_ID)/$(imageName)'
-    dockerfile: '$(Build.SourcesDirectory)/StandAlone.NETCoreApp/Dockerfile.alpine'
-    tags: |
-      $(tag)
-      latest
+    command: login
+    containerRegistry: DockerRegistry
 
-- task: Docker@2
-  displayName: 'Push Docker [$(imageName)(latest,$(tag)]'
-  inputs:
-    command: 'push'
-    containerRegistry: 'DockerRegistry'
-    repository: '$(DOCKER_ID)/$(imageName)'
-    dockerfile: '$(Build.SourcesDirectory)/StandAlone.NETCoreApp/Dockerfile.alpine'
-    tags: |
-      $(tag)
-      latest
+- script: |
+    docker run --privileged --rm tonistiigi/binfmt --install all
+    docker buildx create --use --name builder
+    docker buildx inspect --bootstrap
+  displayName: Set up Docker buildx
+
+- script: |
+    docker buildx build \
+      --platform linux/amd64,linux/arm64 \
+      --tag $(DOCKER_ID)/$(imageName):$(tag) \
+      --tag $(DOCKER_ID)/$(imageName):latest \
+      --file $(Build.SourcesDirectory)/StandAlone.NETCoreApp/Dockerfile.alpine \
+      $(Build.SourcesDirectory)/StandAlone.NETCoreApp \
+      --push
+  displayName: 'Build multi-arch Docker image [$(imageName)(latest,$(tag)]'


### PR DESCRIPTION
## Summary

Adds multi-architecture build support for the Alpine Linux Docker image
(`wiremock.net-alpine`).

The build now uses Docker Buildx to produce a single multi-arch manifest list
covering `linux/amd64` and `linux/arm64`, published under the existing `latest`
and version tags. Because it is one manifest list rather than separate tags,
consumers that already reference `sheyenrath/wiremock.net-alpine` (e.g. the
Aspire and Testcontainers integrations, Docker Compose, Kubernetes) transparently
pull the correct architecture with no changes on their side. This makes the image
run natively on arm64 hosts (Apple Silicon, AWS Graviton, Raspberry Pi 64-bit)
instead of under emulation.

### Changes

- **`StandAlone.NETCoreApp/Dockerfile.alpine`** — cross-compile in the build stage:
  `FROM --platform=$BUILDPLATFORM …sdk:8.0-alpine`, `ARG TARGETARCH`, and
  `dotnet restore -a $TARGETARCH` / `dotnet publish -a $TARGETARCH`. The build
  stage runs natively on the build host and emits a target-arch app, which keeps
  builds fast and avoids QEMU for the .NET compilation.
- **`azure-pipelines-alpine.yml`** — replaced the per-arch build/push tasks with a
  registry login, `binfmt` + `buildx` setup, and a single
  `docker buildx build --platform linux/amd64,linux/arm64 … --push`.

### Notes

- Platforms are limited to `linux/amd64,linux/arm64`. `linux/arm/v7` (arm32) is
  intentionally not included because the .NET Alpine base images do not provide an
  arm32 variant.
- Verified locally with Buildx: both architectures build successfully; the arm64
  image runs natively (`aarch64`) and reports `/__admin/health` healthy in well
  under a second, and the amd64 image is unchanged in behaviour.

## References

Related Issue: #34

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
